### PR TITLE
fix polymer.html path for usage with bower

### DIFF
--- a/quick-element.html
+++ b/quick-element.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../polymer/polymer.html">
 <script>
   (function() {
     var QuickElementPrototype = Object.create(HTMLTemplateElement.prototype);


### PR DESCRIPTION
The file path referenced here works for developers having polymer checked out to that location.

`bower.json` intends to use install the polymer dependency to a sibling folder of `bower_components/quick-element`

(Still breaks the demo, but can be properly embedded into other projects.)
