### PR TITLE
Make demo work out of the box

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,7 @@
   "main": "quick-element.html",
   "license": "MIT",
   "dependencies": {
-    "polymer": "polymer/polymer#0.8-preview"
+    "polymer": "polymer/polymer#0.8-preview",
+    "quick-element": "polymer/quick-element"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,10 +16,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <title>quick-element</title>
 
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 
   <link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>
-  <link href="../quick-element.html" rel="import">
+  <link href="../bower_components/quick-element/quick-element.html" rel="import">
 </head>
 <body>
   <!-- Declare an element called "x-greeter" -->

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <link href="../../font-roboto/roboto.html" rel="import">
+  <link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>
   <link href="../quick-element.html" rel="import">
 </head>
 <body>


### PR DESCRIPTION
The demo further depended on having polymer installed to a sibling directory of `quick-element` (referenced as `../polymer/`). 

With this PR `bower install` will instal the repository to it's own `bower_components/` which is used in `demo/index.html`. That allows to use `quick-element.html`'s relative path to `../polymer/polymer.html` without modification.
