### PR TITLE
polymer version tag #0.8-preview was deprecated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
   "main": "quick-element.html",
   "license": "MIT",
   "dependencies": {
-    "polymer": "polymer/polymer#0.8-preview"
+    "polymer": "polymer/polymer#0.8"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -8,6 +8,6 @@
   "main": "quick-element.html",
   "license": "MIT",
   "dependencies": {
-    "polymer": "polymer/polymer#0.8"
+    "polymer": "polymer/polymer#0.8-rc2"
   }
 }


### PR DESCRIPTION
The [polymer tag list](https://github.com/Polymer/polymer/tags) does not contain `#0.8-preview`.

Depending on release `#0.8` seems the right option for this repo.
